### PR TITLE
Adding specific error logging

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -61,6 +61,7 @@ function App() {
   }
 
    function getAllEvents () {
+    console.log(activeUser, 'in getAllEvents func');
     if(activeUser){
       EventService.getAllEvents(activeUser._id)
       .then(data => {

--- a/client/src/components/Pages/HomePage.js
+++ b/client/src/components/Pages/HomePage.js
@@ -6,6 +6,7 @@ import SearchComponent from "../UI/SearchComponent";
 
 const HomePage = () => {
 const{events} = useContext(Context)
+  console.log('Events:', events);
   return (
     <Layout>
       <div className="no-overflow">

--- a/client/src/components/UI/SearchComponent.js
+++ b/client/src/components/UI/SearchComponent.js
@@ -6,7 +6,7 @@ import Context from '../context/context';
 
 const { Search } = Input;
 const SearchComponent = () => {
-
+  console.log('in search component');
   const {setQuery} = useContext(Context)
 
 

--- a/client/src/components/UserAuth/Login.js
+++ b/client/src/components/UserAuth/Login.js
@@ -27,8 +27,10 @@ const Login = () => {
   }
 
   const handleFormSubmit = async() => {
+    console.log('here1');
     await UserService.loginUser(username, password)
       .then(async(res) => {
+        console.log('here2');
           //await ActiveUserService.setActiveUser(res[0])
       }).then(() => navigate(`/`) )
   }

--- a/client/src/services/active_user_service.js
+++ b/client/src/services/active_user_service.js
@@ -1,6 +1,7 @@
 import {commonHeaders, fetchReq } from "./services_common_data"
 
 const setActiveUser = async (user) => {
+  console.log('in active user service')
   return await fetchReq('set-active-user', {
   method: 'POST',
   headers: {...commonHeaders},

--- a/client/src/services/services_common_data.js
+++ b/client/src/services/services_common_data.js
@@ -6,7 +6,9 @@ export const commonHeaders = {
 }
 
 export const fetchReq = async (url, parameters={}) => {
+  console.log('very fetching!', url)
   return await fetch(`${BASE_URL}/${url}`, parameters)
-  .then(response => response.json())
+  .then(response => {response.json()
+  console.log('far fetched')})
   .catch(err => console.log(err))
 }

--- a/client/src/services/user_service.js
+++ b/client/src/services/user_service.js
@@ -7,7 +7,9 @@ const registerUser = (username, age, password) => fetchReq('register', {
   body: JSON.stringify({username: username, age: age, password: password})
 });
 
-const loginUser = (username,  password) => fetchReq(`login/${username}/${password}`);
+const loginUser = (username,  password) => {
+  console.log('in login user service');
+  fetchReq(`login/${username}/${password}`)};
 
 const getUserById = (userId) => fetchReq(`user/${userId}`);
 

--- a/server/controllers/activeUser_controller.js
+++ b/server/controllers/activeUser_controller.js
@@ -1,7 +1,8 @@
 const ActiveUser = require('../models/activeUser_model');
+const utility_functions = require('../utility_functions');
 
 const setActiveUser = async (req, res) => {
-  console.log(req.body)
+  console.log(`Function name: ${utility_functions.returnFuncName()}\n${req.body}\n`);
   try {
     ActiveUser.create({
       identifier: req.body.identifier,
@@ -18,31 +19,29 @@ const setActiveUser = async (req, res) => {
     })
     res.json(req.body);
     res.status(201);
-  } catch (e) {
+  } catch (error) {
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.status(400);
-    console.log(e);
   }
 };
 
-const getActiveUser = async(req, res) => {
-  try{
+const getActiveUser = async (req, res) => {
+  try {
     const activeUser = await ActiveUser.find({});
-    console.log('activeuser', activeUser)
-    if(activeUser.length != 0){
+    console.log('activeuser', activeUser);
+    if (activeUser.length != 0) {
       res.json(activeUser[0]);
-    }else{
+    } else {
       res.json(false)
     }
-
     res.status(201);
   }
-  catch (e) {
+  catch (error) {
     // res.json(false)
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.status(400);
-    console.log(e);
   }
 }
-
 
 const deleteActiveUser= async(req, res) => {
   console.log('delete', req.body.username)
@@ -51,9 +50,9 @@ const deleteActiveUser= async(req, res) => {
     res.json(req.body);
     res.status(201);
   }
-  catch (e) {
+  catch (error) {
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.status(400);
-    console.log(e);
   }
 }
 

--- a/server/controllers/event_controller.js
+++ b/server/controllers/event_controller.js
@@ -5,6 +5,7 @@ cloudinary.config({
   api_key: process.env.API_KEY,
   api_secret: process.env.API_SECRET,
 });
+const utility_functions = require('../utility_functions');
 
 const addEvent = function(req, res) {
   try{
@@ -27,9 +28,9 @@ const addEvent = function(req, res) {
   })
   res.json(req.body);
   res.status(201)
-  }catch(e){
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.status(400);
-    console.log(e);
   }
 }
 
@@ -44,9 +45,9 @@ const getAllEvents = async function (req, res) {
       }})
     res.json(eventsNonHiddenFromUser)
     res.status(201)
-  }catch(e){
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.status(400);
-    console.log(e);
   }
 }
 
@@ -56,8 +57,8 @@ const addUserToJoinedList = async(req, res) => {
     event.joined.push(req.body.userId)
     event.save();
     res.json(event)
-  }catch(e){
-    console.log(e)
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
   }
 }
 
@@ -68,8 +69,8 @@ const removeUserFromJoinedList = async(req, res) => {
     event.joined = arrayWithoutUnjoinedUser;
     event.save();
     res.json(event)
-  }catch(e){
-    console.log(e)
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
   }
 }
 
@@ -85,16 +86,20 @@ const handleUploadToCloudinary = async (req, res) => {
     const b64 = Buffer.from(req.file.buffer).toString("base64");
     let dataURI = "data:" + req.file.mimetype + ";base64," + b64;
     const cldRes = await handleUpload(dataURI);
-    console.log(cldRes)
+    console.log(`Function name: ${utility_functions.returnFuncName()}\n${cldRes}\n`);
     res.json(cldRes);
   } catch (error) {
-    console.log(error);
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.send({
       message: error.message,
     });
   }
 }
 
-module.exports = {addEvent, getAllEvents, addUserToJoinedList,
+module.exports = {
+  addEvent,
+  getAllEvents,
+  addUserToJoinedList,
   removeUserFromJoinedList,
-  handleUploadToCloudinary}
+  handleUploadToCloudinary
+}

--- a/server/controllers/user_controller.js
+++ b/server/controllers/user_controller.js
@@ -1,6 +1,7 @@
 const User = require('../models/user_model');
 const passport = require('passport');
 var LocalStrategy = require('passport-local');
+const utility_functions = require('../utility_functions');
 
 passport.use(User.createStrategy());
 passport.serializeUser(User.serializeUser());
@@ -22,9 +23,9 @@ const createUser = async (req, res) => {
     }, req.body.password)
     res.json(req.body);
     res.status(201);
-  } catch (e) {
+  } catch (error) {
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.status(400);
-    console.log(e);
   }
 };
 
@@ -33,9 +34,9 @@ const loginUser = async(req, res) => {
     const user = await User.find({username: req.params.username});
     res.json(user)
     res.status(201);
-   } catch(e) {
+   } catch(error) {
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.status(400);
-    console.log(e)
    }
 }
 
@@ -52,9 +53,9 @@ const getAllUsers = async(req, res) => {
     const user = await User.find({});
     res.json(user)
     res.status(201);
-   } catch(e) {
+   } catch(error) {
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
     res.status(400);
-    console.log(e)
    }
 }
 const getUserById = async(req, res) => {
@@ -63,9 +64,9 @@ const getUserById = async(req, res) => {
    console.log(user)
    res.json(user)
    res.status(201);
-  } catch(e) {
+  } catch(error) {
+   console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
    res.status(400);
-   console.log(e)
   }
 }
 
@@ -75,8 +76,8 @@ const addSavedEvent = async(req, res) => {
     user.savedEvents.push(req.body.eventId)
     user.save();
     res.json(user)
-  }catch(e){
-    console.log(e)
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
   }
 }
 
@@ -87,8 +88,8 @@ const removeSavedEvent = async(req, res) => {
     user.savedEvents = arrayWithoutUnsavedEvent;
     user.save();
     res.json(user)
-  }catch(e){
-    console.log(e)
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
   }
 }
 
@@ -98,8 +99,8 @@ const addJoinedEvent = async(req, res) => {
     user.joinedEvents.push(req.body.eventId)
     user.save();
     res.json(user)
-  }catch(e){
-    console.log(e)
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
   }
 }
 
@@ -110,8 +111,8 @@ const removeJoinedEvent = async(req, res) => {
     user.joinedEvents = arrayWithoutUnjoinedEvent;
     user.save();
     res.json(user)
-  }catch(e){
-    console.log(e)
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
   }
 }
 
@@ -125,8 +126,8 @@ const addFriend = async(req, res) => {
     friendUser.friends.push(req.body.activeUserId)
     friendUser.save();
     res.json(activeUser);
-  }catch(e){
-    console.log(e)
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
   }
 }
 
@@ -142,8 +143,8 @@ const removeFriend = async(req, res) => {
     friendUser.friends = FriendUserArrayWithoutFriend;
     friendUser.save();
     res.json(activeUser)
-  }catch(e){
-    console.log(e)
+  }catch(error){
+    console.log(`Error message for function: ${utility_functions.returnFuncName()}\n${error}\n`);
   }
 }
 

--- a/server/db.js
+++ b/server/db.js
@@ -1,18 +1,14 @@
 const mongoose = require('mongoose');
 const DB_PORT = process.env.DB_PORT || 27017;
 const DB_NAME = process.env.DB_NAME || 'imin';
+const DB_URL = process.env.DB_URL || `mongodb://localhost:${DB_PORT}/${DB_NAME}`; // added by Ali
 
-try{
-  mongoose.connect(
-    `mongodb://localhost:${DB_PORT}/${DB_NAME}`
-  )
-}catch(err){
-  if (err) {
-    console.log(`😞 Sorry, something went wrong! ${err}`);
-  } else {
-    console.log(`🦆 Database (sessions) connected @ port ${DB_PORT}!`);
-  }
-}
-
+mongoose
+  .connect(DB_URL, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true
+  })
+  .then(() => console.log(`🦆 Database (sessions) connected @ URL ${DB_URL}!`))
+  .catch((error) => console.log(`😞 Sorry, something went wrong! ${error}`));
 
 module.exports = mongoose;

--- a/server/index.js
+++ b/server/index.js
@@ -13,19 +13,19 @@ app.use(cors())
 app.use(express.json());
 app.use(bodyParser.urlencoded({ extended: false }))
 
-app.use(session({
-  key: 'user_sid',
-  secret: process.env.SESSION_SECRET,
-  resave: true,
-  saveUninitialized: false,
-  cookie: {
-    expires: 10800000, // 3 hours
-    httpOnly: false
-  }
-}))
-app.use(passport.initialize());
+// app.use(session({
+//   key: 'user_sid',
+//   secret: process.env.SESSION_SECRET,
+//   resave: true,
+//   saveUninitialized: false,
+//   cookie: {
+//     expires: 10800000, // 3 hours
+//     httpOnly: false
+//   }
+// }))
+// app.use(passport.initialize());
 
-app.use(passport.session());
+// app.use(passport.session());
 
 app.use(router);
 

--- a/server/utility_functions.js
+++ b/server/utility_functions.js
@@ -1,0 +1,7 @@
+function returnFuncName () {
+  return returnFuncName.caller.name
+};
+
+module.exports = {
+  returnFuncName
+};


### PR DESCRIPTION
Improved error logging within `try | catch` blocks of controller files. Changed `console.log(e)` to `console.log('Error message for function: ${utility_functions.returnFuncName()}\n${error}\n')`, where `returnFuncName` is a utility function I've written to return the name of the function. In this way, the error message specifies which function is erroring. 

I added this code to address a problem I experienced when trying to setup the project, where `**null**` was being printed to the console, but it wasn't clear which function was responsible - so I had to change each function that logged to console and, through trial and error, ascertain which function was responsible.

Within the `try | catch` blocks, `res.status(400)` was being called BEFORE logging the error to the console. This meant, when experiencing an error, it is rarely logged to the console - because it stops execution at the `res.status(400)` stage. I've moved the `console.log` above the `res.status(400)` line in all the functions, so that it always logs to the console and we always get specific error messages to help with debugging.

Also, as a convention (mentioned in Notion ticket **Defining programming conventions for our project**), errors will be captured as `(error)` - not as `(err)` or `(e)`.